### PR TITLE
chore: Use toktok-stack 0.0.23 for cirrus builds.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,13 +1,13 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.11
+    image: toxchat/toktok-stack:0.0.23-third_party
     cpu: 2
     memory: 4G
   configure_script:
     - /src/workspace/tools/inject-repo experimental
   test_all_script:
-    - bazel test -k
+    - cd /src/workspace && bazel test -k
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST
         --config=release
         //experimental/...


### PR DESCRIPTION
This version has pre-built third party binaries, speeding up the build.