### PR TITLE
chore: Use latest instead of versioned toktok-stack image.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.31-release
+    image: toxchat/toktok-stack:latest-release
     cpu: 2
     memory: 4G
   configure_script:


### PR DESCRIPTION
Versioning is no longer needed.