### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,5 +8,4 @@ cirrus-ci_task:
     - /src/workspace/tools/inject-repo experimental
   test_all_script:
     - cd /src/workspace && bazel test -k
-        --config=ci
         //experimental/...

--- a/users/iphydf/camera/BUILD.bazel
+++ b/users/iphydf/camera/BUILD.bazel
@@ -53,6 +53,7 @@ cc_library(
         "//tools/config:windows": [],
     }),
     includes = ["."],
+    tags = ["no-cross"],
     deps = [
         "@gl",
         "@qt//:qt_core",
@@ -65,5 +66,6 @@ cc_library(
 
 cc_binary(
     name = "camera",
+    tags = ["no-cross"],
     deps = [":camera_main"],
 )

--- a/users/iphydf/qt-toxcore-c/BUILD.bazel
+++ b/users/iphydf/qt-toxcore-c/BUILD.bazel
@@ -35,6 +35,7 @@ cc_library(
     ],
     copts = COPTS,
     includes = ["."],
+    tags = ["no-cross"],
     deps = [
         "//c-toxcore",
         "@qt//:qt_core",


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.