### PR TITLE
chore: Add some more things to no-cross.

### DIFF
--- a/users/iphydf/camera/BUILD.bazel
+++ b/users/iphydf/camera/BUILD.bazel
@@ -13,6 +13,7 @@ qt_moc(
         "imagesettings.h",
         "videosettings.h",
     ],
+    tags = ["no-cross"],
     deps = ["@qt//:qt_widgets"],
 )
 
@@ -26,6 +27,7 @@ qt_uic(
         "imagesettings.ui",
         "videosettings.ui",
     ],
+    tags = ["no-cross"],
 )
 
 # Main binary


### PR DESCRIPTION
Needed for remote-exec, because it doesn't support Qt, yet.